### PR TITLE
Add SAB treasury withdrawal script for DAO operations and Avantgarde deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The earlier history is documented in [`/history`](history/).
 - [`2023-04-vesting-release`](scripts/2023-04-vesting-release.js): release MANA vesting to Decentraland DAO
 - [`2024-03-estate-upgrade`](scripts/2024-03-estate-upgrade.js): upgrade implementation of Estate Registry contract
 - [`2024-03-committee-change`](scripts/2024-03-committee-change.js): rotate a committee member
+- [`2026-06-treasury-withdrawal`](scripts/2026-06-treasury-withdrawal.js): withdraw treasury assets to Council Ops and Avantgarde+DCL multisigs
 
 ## Run
 

--- a/history/2026-06-treasury-withdrawal.md
+++ b/history/2026-06-treasury-withdrawal.md
@@ -1,0 +1,24 @@
+# 2026-06 Treasury withdrawal
+
+In June 2026, the DAO Council requested an SAB vote to withdraw assets from the Decentraland DAO treasury to fund day-to-day operations and begin capital deployment under the community-approved Treasury Mandate.
+
+This followed the deprecation of the legacy DAO Committee, the removal of Kyllian (HPrivakos) from the SAB, and the revocation of legacy Committee Delay treasury access. With the SAB able to act again, the Council requested moving funds from the DAO treasury to two Safe multisigs:
+
+- Council Ops multisig: `0x184e4D9A26Add0aF1eAfC145550E890a421f16d7`
+- Avantgarde+DCL multisig: `0x96e2F6099860731CFdc0AF700dE862cf6EbA4407`
+
+The withdrawal was approved in the DCL DAO Council Snapshot proposal [Treasury Withdrawal to Operational Multisig for DAO Operations and Capital Deployment to Avantgarde](https://snapshot.box/#/s:daocouncil.dcl.eth/proposal/0x866e65525317e6dda4913533e279989dee28e8c033acf705b54a843d813a545a).
+
+The requested payment matrix was:
+
+| Amount     | Asset | Recipient               |
+| ---------- | ----- | ----------------------- |
+| 16,940     | DAI   | Council Ops multisig    |
+| 4,444      | USDC  | Council Ops multisig    |
+| 3,331,245  | MANA  | Council Ops multisig    |
+| 20,000,000 | MANA  | Avantgarde+DCL multisig |
+| 339        | ETH   | Avantgarde+DCL multisig |
+
+See [related script](/scripts/2026-06-treasury-withdrawal.js) on how this change was prepared for the DAO.
+
+The ERC-20 payments are encoded as `Finance.newImmediatePayment(...)` calls. Native ETH is handled separately through `Agent.execute(...)` because Aragon's Finance app delegates transfers to the Vault, and the Vault uses Solidity `send()` for native ETH. That path can fail for Safe recipients, so the script sends native ETH from the Agent with a low-level value transfer instead.

--- a/scripts/2026-06-treasury-withdrawal.js
+++ b/scripts/2026-06-treasury-withdrawal.js
@@ -1,0 +1,195 @@
+const ethers = require('ethers')
+const abi = require('web3-eth-abi')
+
+const { abis, utils } = require('../src')
+
+const {
+  chainEnv,
+  debug,
+  encoding: { encodeCallsScript, encodeForward },
+} = utils
+
+const SNAPSHOT_PROPOSAL_ID = '0x866e65525317e6dda4913533e279989dee28e8c033acf705b54a843d813a545a'
+
+const TOKENS = {
+  DAI: {
+    address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+    decimals: 18,
+  },
+  USDC: {
+    address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    decimals: 6,
+  },
+  MANA: {
+    address: '0x0F5D2fB29fb7d3CFeE444a200298f468908cC942',
+    decimals: 18,
+  },
+  ETH: {
+    // Aragon Finance and Vault use address(0) as the native ETH sentinel.
+    address: ethers.constants.AddressZero,
+    decimals: 18,
+    native: true,
+  },
+}
+
+const RECIPIENTS = {
+  councilOpsMultisig: {
+    label: 'Council Ops multisig',
+    address: '0x184e4D9A26Add0aF1eAfC145550E890a421f16d7',
+  },
+  avantgardeDclMultisig: {
+    label: 'Avantgarde+DCL multisig',
+    address: '0x96e2F6099860731CFdc0AF700dE862cf6EbA4407',
+  },
+}
+
+const payments = [
+  {
+    amount: '16940',
+    displayAmount: '16,940',
+    ticker: 'DAI',
+    recipient: RECIPIENTS.councilOpsMultisig,
+  },
+  {
+    amount: '4444',
+    displayAmount: '4,444',
+    ticker: 'USDC',
+    recipient: RECIPIENTS.councilOpsMultisig,
+  },
+  {
+    amount: '3331245',
+    displayAmount: '3,331,245',
+    ticker: 'MANA',
+    recipient: RECIPIENTS.councilOpsMultisig,
+  },
+  {
+    amount: '20000000',
+    displayAmount: '20,000,000',
+    ticker: 'MANA',
+    recipient: RECIPIENTS.avantgardeDclMultisig,
+  },
+  {
+    amount: '339',
+    displayAmount: '339',
+    ticker: 'ETH',
+    recipient: RECIPIENTS.avantgardeDclMultisig,
+  },
+]
+
+const { orgUrl, kernel, acl, agent, finance, sabVoting, sabTokenManager } = chainEnv.buildConfig()
+
+function getToken(ticker) {
+  return TOKENS[ticker]
+}
+
+function getPaymentAmount(payment) {
+  const token = getToken(payment.ticker)
+  return ethers.utils.parseUnits(payment.amount, token.decimals).toString()
+}
+
+function getPaymentReference(payment) {
+  return `DCL DAO treasury withdrawal approved by Snapshot ${SNAPSHOT_PROPOSAL_ID}: ${payment.ticker} to ${payment.recipient.label}`
+}
+
+function getPaymentAction(payment) {
+  const token = getToken(payment.ticker)
+
+  if (token.native) {
+    return {
+      to: agent,
+      data: abi.encodeFunctionCall(abis.AGENT_EXECUTE, [payment.recipient.address, getPaymentAmount(payment), '0x']),
+    }
+  }
+
+  return {
+    to: finance,
+    data: abi.encodeFunctionCall(abis.FINANCE_NEW_IMMEDIATE_PAYMENT, [
+      token.address,
+      payment.recipient.address,
+      getPaymentAmount(payment),
+      getPaymentReference(payment),
+    ]),
+  }
+}
+
+function getAssetAddressLabel(payment) {
+  const token = getToken(payment.ticker)
+
+  if (token.native) {
+    return `${token.address} (native ETH sentinel)`
+  }
+
+  return token.address
+}
+
+/*******************
+ * BUILD EVMSCRIPT *
+ *******************/
+
+async function main() {
+  if (chainEnv.getName() !== 'mainnet') {
+    throw new Error('This treasury withdrawal proposal is only intended for mainnet')
+  }
+
+  console.log()
+  console.log('============================================================')
+  console.log()
+  console.log(`Planning modifications to the Decentraland DAO on network ${chainEnv.getName()}:`)
+  console.log('  Withdraw treasury assets to Council Ops and Avantgarde+DCL multisigs')
+  console.log()
+  console.log('This organization will be targetted:')
+  console.log(`  - Url:                     ${orgUrl}`)
+  console.log(`  - Kernel:                  ${kernel}`)
+  console.log(`  - ACL:                     ${acl}`)
+  console.log(`  - Treasury Agent:          ${agent}`)
+  console.log(`  - Finance:                 ${finance}`)
+  console.log(`  - SAB Voting:              ${sabVoting}`)
+  console.log(`  - SAB Token Manager:       ${sabTokenManager}`)
+  console.log()
+  console.log('Proposal:')
+  console.log(`  - Snapshot:                ${SNAPSHOT_PROPOSAL_ID}`)
+  console.log()
+  console.log('And planning these payments as steps:')
+
+  for (const [index, payment] of payments.entries()) {
+    const paymentLabel = `${payment.displayAmount} ${payment.ticker} to ${payment.recipient.label}`
+    const mechanism = getToken(payment.ticker).native
+      ? 'Agent.execute native ETH transfer'
+      : 'Finance.newImmediatePayment'
+
+    console.log(`  ${index + 1}. ${paymentLabel} (${payment.recipient.address})`)
+    console.log(`      - Mechanism:           ${mechanism}`)
+    console.log(`      - Asset address:       ${getAssetAddressLabel(payment)}`)
+    console.log(`      - Amount base units:   ${getPaymentAmount(payment)}`)
+  }
+
+  console.log()
+  console.log('============================================================')
+  console.log()
+
+  const treasuryWithdrawalScriptSteps = payments.map((payment) => getPaymentAction(payment))
+  const treasuryWithdrawalCallsScript = encodeCallsScript(treasuryWithdrawalScriptSteps)
+  const sabVoteForwardDataForTokenManager = encodeForward(treasuryWithdrawalCallsScript)
+  const sabVoteForwardCallScriptForTokenManager = encodeCallsScript([
+    { to: sabVoting, data: sabVoteForwardDataForTokenManager },
+  ])
+  const sabForwardDataForTokenManager = encodeForward(sabVoteForwardCallScriptForTokenManager)
+
+  console.log('Withdraw treasury assets')
+  console.log('  Raw data to create a vote through SAB Token Manager:')
+  console.log(`    ${sabForwardDataForTokenManager}`)
+  console.log()
+  console.log('  Send as raw transaction with:')
+  console.log(`    { "to": "${sabTokenManager}", "data": "${sabForwardDataForTokenManager}" }`)
+  console.log()
+
+  debug(`Calls script steps for treasury withdrawal (length: ${treasuryWithdrawalScriptSteps.length}):`)
+  debug(treasuryWithdrawalScriptSteps)
+  debug()
+}
+
+/*******
+ * RUN *
+ *******/
+
+main()

--- a/src/abis.js
+++ b/src/abis.js
@@ -258,6 +258,33 @@ const AGENT_EXECUTE = {
   type: 'function',
 }
 
+const FINANCE_NEW_IMMEDIATE_PAYMENT = {
+  constant: false,
+  inputs: [
+    {
+      name: '_token',
+      type: 'address',
+    },
+    {
+      name: '_receiver',
+      type: 'address',
+    },
+    {
+      name: '_amount',
+      type: 'uint256',
+    },
+    {
+      name: '_reference',
+      type: 'string',
+    },
+  ],
+  name: 'newImmediatePayment',
+  outputs: [],
+  payable: false,
+  stateMutability: 'nonpayable',
+  type: 'function',
+}
+
 const LIST_INITIALIZE = {
   constant: false,
   inputs: [
@@ -377,6 +404,7 @@ module.exports = {
   DELAY_INITIALIZE,
   CATALYST_REMOVE_CATALYST,
   AGENT_EXECUTE,
+  FINANCE_NEW_IMMEDIATE_PAYMENT,
   LIST_INITIALIZE,
 
   // External contracdts


### PR DESCRIPTION
## Summary

Adds the June 2026 treasury withdrawal script for the approved [DAO Council Snapshot proposal](https://snapshot.box/#/s:daocouncil.dcl.eth/proposal/0x866e65525317e6dda4913533e279989dee28e8c033acf705b54a843d813a545a).

The script creates an SAB vote that withdraws:

- 16,940 DAI, 4,444 USDC, and 3,331,245 MANA to the Council Ops multisig
- 20,000,000 MANA and 339 ETH to the Avantgarde+DCL multisig

ERC-20 transfers are encoded through `Finance.newImmediatePayment`. Native ETH is handled through `Agent.execute` because the Aragon Vault ETH transfer path uses `send()`, which can revert for Safe recipients.

## Changes

- Adds the Finance `newImmediatePayment` ABI.
- Adds `scripts/2026-06-treasury-withdrawal.js`.
- Adds `history/2026-06-treasury-withdrawal.md`.
- Updates the script index in `README.md`.

## Validation

- `npm run lint`
- `npm run test --if-present`
- `node scripts/2026-06-treasury-withdrawal.js`